### PR TITLE
Npm publishing user docs

### DIFF
--- a/getting-started.md
+++ b/getting-started.md
@@ -41,11 +41,11 @@ So all you need to do in order to use Simple.css in your project, is add the fol
 
 To install with npm or Yarn
 ```
-$ npm install simple.css
+$ npm install @kevquirk/simple.css
 
 # or
 
-$ yarn add simple.css
+$ yarn add @kevquirk/simple.css
 ```
 
 For example, using a bundler like **webpack**, you can consume simple.css using an `@import` in a CSS file

--- a/getting-started.md
+++ b/getting-started.md
@@ -27,7 +27,7 @@ Now, whenever I publish an update to Simple.css, you will automatically receive 
 
 ## Option 2) - UNPKG.com - CDN for npm
 
-Whenever we push a new version to [**npm**](https://www.npmjs.com/) a minified and unminified version of the CSS will be available in [**unpkg**](https://unpkg.com/).
+Whenever we publish a new version to [**npm**](https://www.npmjs.com/) a minified and unminified version of the CSS will be available in [**unpkg**](https://unpkg.com/).
 
 So all you need to do in order to use Simple.css in your project, is add the following line of code to the `<head>` section of your HTML:
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -32,7 +32,7 @@ Whenever we publish a new version to [**npm**](https://www.npmjs.com/) a minifie
 So all you need to do in order to use Simple.css in your project, is add the following line of code to the `<head>` section of your HTML:
 
 ```
-<link rel="stylesheet" href="https://unpkg.com/simple.css/simple.min.css">
+<link rel="stylesheet" href="https://unpkg.com/simpledotcss/simple.min.css">
 ```
 
 ## Option 3) - Install from npm
@@ -41,16 +41,16 @@ So all you need to do in order to use Simple.css in your project, is add the fol
 
 To install with npm or Yarn
 ```
-$ npm install simplecss
+$ npm install simpledotcss
 
 # or
 
-$ yarn add simplecss
+$ yarn add simpledotcss
 ```
 
-For example, using a bundler like **webpack**, you can consume simple.css using an `@import` in a CSS file
+For example, using a bundler like **webpack**, you can consume _simple.css_ using an `@import` statement in a CSS file
 ```
-@import url('~simplecss/simple.min.css');
+@import url('~simpledotcss/simple.min.css');
 ```
 
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -41,16 +41,16 @@ So all you need to do in order to use Simple.css in your project, is add the fol
 
 To install with npm or Yarn
 ```
-$ npm install @kevquirk/simple.css
+$ npm install simplecss
 
 # or
 
-$ yarn add @kevquirk/simple.css
+$ yarn add simplecss
 ```
 
 For example, using a bundler like **webpack**, you can consume simple.css using an `@import` in a CSS file
 ```
-@import url('~simple.css/simple.min.css');
+@import url('~simplecss/simple.min.css');
 ```
 
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -25,7 +25,7 @@ So all you need to do in order to use Simple.css in your project, is add the fol
 
 Now, whenever I publish an update to Simple.css, you will automatically receive it.
 
-## Option 2) - UNPKG.com - CDN for npm
+## Option 2 - UNPKG.com (CDN for npm)
 
 Whenever we publish a new version to [**npm**](https://www.npmjs.com/) a minified and unminified version of the CSS will be available in [**unpkg**](https://unpkg.com/).
 
@@ -35,7 +35,7 @@ So all you need to do in order to use Simple.css in your project, is add the fol
 <link rel="stylesheet" href="https://unpkg.com/simpledotcss/simple.min.css">
 ```
 
-## Option 3) - Install from npm
+## Option 3 - Install from npm
 
 [npm](https://www.npmjs.com/) is a package registry installing JavaScript and other frontend packages, for NodeJS and browsers.  If you're using any sort of build process (webpack, gulp, browserify,etc), you can manage simple.css as dependency in your project's _package.json_.
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -25,7 +25,36 @@ So all you need to do in order to use Simple.css in your project, is add the fol
 
 Now, whenever I publish an update to Simple.css, you will automatically receive it.
 
-## Option 2 - self-host Simple.css
+## Option 2) - UNPKG.com - CDN for npm
+
+Whenever we push a new version to [**npm**](https://www.npmjs.com/) a minified and unminified version of the CSS will be available in **unpkg**.
+
+So all you need to do in order to use Simple.css in your project, is add the following line of code to the `<head>` section of your HTML:
+
+```
+<link rel="stylesheet" href="https://unpkg.com/simple.css/simple.min.css">
+```
+
+## Option 3) - Install from npm
+
+[npm](https://www.npmjs.com/) is a package registry installing JavaScript and other frontend packages, for NodeJS and browsers.  If you're using any sort of build process (webpack, gulp, browserify,etc), you can manage simple.css as dependency in your project's _package.json_.
+
+To install with npm or Yarn
+```
+$ npm install simple.css
+
+# or
+
+$ yarn add simple.css
+```
+
+For example, using a bundler like **webpack**, you can consume simple.css using an `@import` in a CSS file
+```
+@import url('~simple.css/simple.min.css');
+```
+
+
+## Option 4 - Self-host Simple.css
 
 Of course, you don't have to use the CDN delivery method. If you prefer, you can host Simple.css yourself; but you won't automatically receive updates to the CSS as it is released. You would need to re-download the source and update your project yourself.
 

--- a/getting-started.md
+++ b/getting-started.md
@@ -27,7 +27,7 @@ Now, whenever I publish an update to Simple.css, you will automatically receive 
 
 ## Option 2) - UNPKG.com - CDN for npm
 
-Whenever we push a new version to [**npm**](https://www.npmjs.com/) a minified and unminified version of the CSS will be available in **unpkg**.
+Whenever we push a new version to [**npm**](https://www.npmjs.com/) a minified and unminified version of the CSS will be available in [**unpkg**](https://unpkg.com/).
 
 So all you need to do in order to use Simple.css in your project, is add the following line of code to the `<head>` section of your HTML:
 


### PR DESCRIPTION
documentation to accompany https://github.com/kevquirk/simple.css/issues/11 by adding docs for:
- Usage from unpkg CDN
- Usage with npm / bundlers


> _**Note**: as is being discussed in [the issue](https://github.com/kevquirk/simple.css/pull/21), we will just need to make sure the package name we decide on there matches what is in the docs here._