### PR TITLE
Fix radio inputs UX

### DIFF
--- a/demo.md
+++ b/demo.md
@@ -268,9 +268,9 @@ Forms are useful for all kinds of things on webpages. Contact forms, newsletter 
   </p>
   <p>
   <label>Enquiry type:</label><br>
-  <label><input checked="checked" name="type" type="radio" value="sales" /> Sales <label><br />
-	<label><input name="type" type="radio" value="support" /> Support <label><br />
-  <label><input name="type" type="radio" value="billing" /> Billing<label>
+  <label><input checked="checked" name="type" type="radio" value="sales" /> Sales </label><br />
+	<label><input name="type" type="radio" value="support" /> Support </label><br />
+  <label><input name="type" type="radio" value="billing" /> Billing</label>
   </p>
   <p>
   <label>Message</label><br>
@@ -317,9 +317,9 @@ Forms are useful for all kinds of things on webpages. Contact forms, newsletter 
 
   <p>
   <label>Enquiry type:</label><br>
-  <input checked="checked" name="type" type="radio" value="sales" /> Sales <br />
-  <input name="type" type="radio" value="support" /> Support <br />
-  <input name="type" type="radio" value="billing" /> Billing
+  <label><input checked="checked" name="type" type="radio" value="sales" /> Sales</label> <br />
+  <label><input name="type" type="radio" value="support" /> Support</label> <br />
+  <label><input name="type" type="radio" value="billing" /> Billing</label>
   </p>
 
   <p>

--- a/demo.md
+++ b/demo.md
@@ -268,9 +268,9 @@ Forms are useful for all kinds of things on webpages. Contact forms, newsletter 
   </p>
   <p>
   <label>Enquiry type:</label><br>
-  <input checked="checked" name="type" type="radio" value="sales" /> Sales <br />
-	<input name="type" type="radio" value="support" /> Support <br />
-  <input name="type" type="radio" value="billing" /> Billing
+  <label><input checked="checked" name="type" type="radio" value="sales" /> Sales <label><br />
+	<label><input name="type" type="radio" value="support" /> Support <label><br />
+  <label><input name="type" type="radio" value="billing" /> Billing<label>
   </p>
   <p>
   <label>Message</label><br>


### PR DESCRIPTION
By wrapping radio/checkbox inputs with a label element, the input text becomes clickable
#7 